### PR TITLE
New agentkeepalive

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   "homepage": "https://github.com/mapbox/tilelive-overlay",
   "devDependencies": {
     "tap": "~0.4.8",
-    "mapnik": "3.x",
+    "mapnik": "3.2.x",
     "queue-async": "~1.0.7",
     "benchmark": "~1.0.0"
   },
   "dependencies": {
     "sphericalmercator": "~1.0.2",
-    "geojson-mapnikify": "https://github.com/mapbox/geojson-mapnikify/tarball/new-keep-alive"
+    "geojson-mapnikify": "~0.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "sphericalmercator": "~1.0.2",
-    "geojson-mapnikify": "0.4.x"
+    "geojson-mapnikify": "https://github.com/mapbox/geojson-mapnikify/tarball/new-keep-alive"
   }
 }


### PR DESCRIPTION
Bump geojson-mapnikify to upgrade node-agentkeepalive to v2.0.2.