### PR TITLE
Fix try/catch scope to apply only to JSON.parse()

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,18 +45,20 @@ function Source(id, callback) {
         data = data.replace(/^legacy:/, '');
     }
 
+    var parsed;
     try {
-        var parsed = JSON.parse(data);
-        var generated = mapnikify(parsed, retina, function(err, xml) {
-            if (err) return callback(err);
-            this._xml = xml;
-            this._size = retina && !legacy ? 512 : 256;
-            this._bufferSize = retina ? 128 : 64;
-            callback(null, this);
-        }.bind(this));
+        parsed = JSON.parse(data);
     } catch(e) {
         return callback('invalid geojson');
     }
+
+    mapnikify(parsed, retina, function(err, xml) {
+        if (err) return callback(err);
+        this._xml = xml;
+        this._size = retina && !legacy ? 512 : 256;
+        this._bufferSize = retina ? 128 : 64;
+        callback(null, this);
+    }.bind(this));
 }
 
 /**


### PR DESCRIPTION
Fixes try/catch scope -- atm is too greedy, triggering an `invalid geojson` error even for caught errors further down the line.