### PR TITLE
Bump to 1.0.0, updated mapnik to 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## v0.9.0
+## v1.0.0
 
  - Updated to use mapnik 3.7.0
+ - Updated geojson-mapnikify to 1.0.0
+ - Dropped support for windows
 
 ## v0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.9.0
+
+ - Updated to use mapnik 3.7.0
+
 ## v0.8.0
 
  - Updated to use mapnik 3.6.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive-overlay",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "use geojson and simplestyle features rendered with mapnik",
   "main": "index.js",
   "scripts": {
@@ -24,12 +24,12 @@
   "homepage": "https://github.com/mapbox/tilelive-overlay",
   "devDependencies": {
     "tap": "~0.4.8",
-    "mapnik": "~3.6.0",
+    "mapnik": "~3.7.0",
     "queue-async": "~1.0.7",
     "benchmark": "~1.0.0"
   },
   "dependencies": {
     "@mapbox/sphericalmercator": "~1.0.2",
-    "@mapbox/geojson-mapnikify": "~0.8.0"
+    "@mapbox/geojson-mapnikify": "~0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/tilelive-overlay",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "use geojson and simplestyle features rendered with mapnik",
   "main": "index.js",
   "scripts": {
@@ -30,6 +30,6 @@
   },
   "dependencies": {
     "@mapbox/sphericalmercator": "~1.0.2",
-    "@mapbox/geojson-mapnikify": "~0.9.0"
+    "@mapbox/geojson-mapnikify": "~1.0.0"
   }
 }


### PR DESCRIPTION
Updates mapnik to 3.7.0, geojson-mapnikify to 1.0.0. Releases as new 1.0.0 due to dropping of windows support with mapnik 3.7.0